### PR TITLE
[Bugfix] Fix topk_ids indices_type for cutlass w8a8 fp8 moe

### DIFF
--- a/csrc/quantization/cutlass_w8a8/moe/moe_data.cu
+++ b/csrc/quantization/cutlass_w8a8/moe/moe_data.cu
@@ -7,7 +7,7 @@
 
 constexpr uint64_t THREADS_PER_EXPERT = 512;
 
-__global__ void compute_problem_sizes(const uint32_t* __restrict__ topk_ids,
+__global__ void compute_problem_sizes(const int32_t* __restrict__ topk_ids,
                                       int32_t* problem_sizes1,
                                       int32_t* problem_sizes2,
                                       int32_t* atomic_buffer,
@@ -62,7 +62,7 @@ __global__ void compute_expert_blockscale_offsets(
   }
 }
 
-__global__ void compute_arg_sorts(const uint32_t* __restrict__ topk_ids,
+__global__ void compute_arg_sorts(const int32_t* __restrict__ topk_ids,
                                   const int32_t* __restrict__ expert_offsets,
                                   int32_t* input_permutation,
                                   int32_t* output_permutation,
@@ -103,7 +103,7 @@ void get_cutlass_moe_mm_data_caller(
 
   int num_threads = min(THREADS_PER_EXPERT, topk_ids.numel());
   compute_problem_sizes<<<num_experts, num_threads, 0, stream>>>(
-      static_cast<const uint32_t*>(topk_ids.data_ptr()),
+      static_cast<const int32_t*>(topk_ids.data_ptr()),
       static_cast<int32_t*>(problem_sizes1.data_ptr()),
       static_cast<int32_t*>(problem_sizes2.data_ptr()),
       static_cast<int32_t*>(atomic_buffer.data_ptr()), topk_ids.numel(), n, k);
@@ -120,7 +120,7 @@ void get_cutlass_moe_mm_data_caller(
         static_cast<int32_t*>(atomic_buffer.data_ptr()), num_experts);
   }
   compute_arg_sorts<<<num_experts, num_threads, 0, stream>>>(
-      static_cast<const uint32_t*>(topk_ids.data_ptr()),
+      static_cast<const int32_t*>(topk_ids.data_ptr()),
       static_cast<const int32_t*>(expert_offsets.data_ptr()),
       static_cast<int32_t*>(input_permutation.data_ptr()),
       static_cast<int32_t*>(output_permutation.data_ptr()),

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -621,8 +621,7 @@ class CompressedTensorsW8A8Fp8MoECutlassMethod(CompressedTensorsMoEMethod):
             num_expert_group=num_expert_group,
             custom_routing_function=custom_routing_function,
             scoring_func=scoring_func,
-            e_score_correction_bias=e_score_correction_bias,
-            indices_type=torch.uint32)
+            e_score_correction_bias=e_score_correction_bias)
 
         return self.fused_experts(
             x,


### PR DESCRIPTION
## Purpose

This PR fixes the following error when starting EP on Maverick:

```
(VllmWorker rank=3 pid=1737537) ERROR 06-15 22:58:28 [multiproc_executor.py:527]     run_cutlass_moe_fp8(output, hidden_states, w1, w2, topk_ids,
(VllmWorker rank=3 pid=1737537) ERROR 06-15 22:58:28 [multiproc_executor.py:527]   File "/home/yeq/gitrepos/vllm/vllm/model_executor/layers/fused_moe/cutlass_moe.py", line 89, in run_cutlass_moe_fp8
(VllmWorker rank=3 pid=1737537) ERROR 06-15 22:58:28 [multiproc_executor.py:527]     local_topk_ids = torch.where(expert_map[topk_ids] != -1,
(VllmWorker rank=3 pid=1737537) ERROR 06-15 22:58:28 [multiproc_executor.py:527]                                  ~~~~~~~~~~^^^^^^^^^^
(VllmWorker rank=3 pid=1737537) ERROR 06-15 22:58:28 [multiproc_executor.py:527] IndexError: tensors used as indices must be long, int, byte or bool tensors
```

In the PPLX implementation https://github.com/vllm-project/vllm/pull/18762, the dtype got flipped to uint32, [here](https://github.com/vllm-project/vllm/pull/18762/files#diff-ff1294eac1d5278b98c34982811d183967f327696bfdcc7f546d3b8c0d44f6ebR606).

Besides this PR, the `workspace_shapes` needs the fix [here](https://github.com/vllm-project/vllm/pull/19168/files#diff-9b016dd434128a65d01ca04b5a1f6e964626771707d1a70db1ec7cf7b309ec82R243) from #19168; otherwise, the torch.zeros is slow for processing much larger size of data [here](https://github.com/vllm-project/vllm/pull/19168/files#diff-73262921f7ba97b74df4aebe0956f21dfaf1d035a1c47d1c5321b29f1ac0a36cL318).


## Test Plan

```bash
# serve
vllm serve meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 \
        --max_model_len 8192 \
        --kv_cache_dtype fp8 \
        --enable-expert-parallel \
        --tensor-parallel-size 8 \
        --trust-remote-code \
        --enforce_eager \
        --gpu-memory-utilization 0.8 \
        --disable-log-requests 2>&1 | tee .env/ep_`date +%Y%m%d_%H%M%S`.log
# benchmark serve
python benchmarks/benchmark_serving.py  --model meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 \
        --port 8000  --dataset-name random  --ignore-eos  --num-prompts 500   --max-concurrency 128 \
        --random-input-len 2000 --random-output-len 150
```

## Test Result

```
============ Serving Benchmark Result ============
Successful requests:                     500
Benchmark duration (s):                  42.34
Total input tokens:                      998815
Total generated tokens:                  75000
Request throughput (req/s):              11.81
Output token throughput (tok/s):         1771.43
Total Token throughput (tok/s):          25362.46
---------------Time to First Token----------------
Mean TTFT (ms):                          1119.22
Median TTFT (ms):                        384.95
P99 TTFT (ms):                           5939.92
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          63.31
Median TPOT (ms):                        66.14
P99 TPOT (ms):                           67.69
---------------Inter-token Latency----------------
Mean ITL (ms):                           63.31
Median ITL (ms):                         33.70
P99 ITL (ms):                            198.63
==================================================
```

## (Optional) Documentation Update

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
